### PR TITLE
support survey answers for checkboxes (multiple answers)

### DIFF
--- a/lp_api_wrapper/parsers/engagement_history/events.py
+++ b/lp_api_wrapper/parsers/engagement_history/events.py
@@ -234,7 +234,7 @@ class ServiceActivity(namedtuple('ServiceActivity', service_activity_columns)):
 
 
 survey_columns = ['engagementId', 'engagementSequence', 'displayName', 'name', 'questionID', 'scope', 'source', 'surveyID', 'surveyType',
-                  'time', 'timeL', 'value']
+                  'time', 'timeL', 'value', 'values']
 
 
 class Survey(namedtuple('Survey', survey_columns)):


### PR DESCRIPTION
Multiple answers in a survey (checkboxes) are held in the 'values' property and do not display in the 'value' property.